### PR TITLE
add dockerfile, reflex and make target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 .idea/
 *.iml
 *.iws
+
+.go/

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,0 +1,9 @@
+FROM golang:1.16-stretch AS base
+
+ENV GOCACHE=/go/.go/cache GOPATH=/go/.go/path TZ=Europe/London
+
+RUN GOBIN=/bin go get github.com/cespare/reflex
+
+# Map between the working directories of dev and live
+RUN ln -s /go /dp-import-cantabular-dataset
+WORKDIR /dp-import-cantabular-dataset

--- a/Makefile
+++ b/Makefile
@@ -41,3 +41,7 @@ convey:
 .PHONY: test-component
 test-component:
 	go test -v -cover -coverpkg=github.com/ONSdigital/dp-import-cantabular-dataset/... -component
+
+.PHONY: lint
+lint:
+	exit

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,10 @@ debug:
 	go build -tags 'debug' $(LDFLAGS) -o $(BINPATH)/dp-import-cantabular-dataset
 	HUMAN_LOG=1 DEBUG=1 $(BINPATH)/dp-import-cantabular-dataset
 
+.PHONY: debug-run
+debug-run:
+	HUMAN_LOG=1 DEBUG=1 go run -tags 'debug' $(LDFLAGS) main.go
+
 .PHONY: test
 test:
 	go test -v -race -cover ./...

--- a/ci/lint.yml
+++ b/ci/lint.yml
@@ -1,0 +1,15 @@
+---
+
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: golang
+    tag: 1.16.5
+
+inputs:
+  - name: dp-import-cantabular-dataset
+
+run:
+  path: dp-import-cantabular-dataset/ci/scripts/lint.sh

--- a/ci/scripts/lint.sh
+++ b/ci/scripts/lint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -eux
+
+cwd=$(pwd)
+
+pushd $cwd/dp-import-cantabular-dataset
+  make lint
+popd

--- a/reflex
+++ b/reflex
@@ -1,1 +1,4 @@
+# Watch all files ending in .go, excluding files in `.go` or `cmd` directory
+# or files ending in `_test.go` & run `make debug-run` when any matching file
+# is changed
 -s -r \.go$ -R ^\.go/ -R ^cmd/ -R _test\.go$ make debug-run

--- a/reflex
+++ b/reflex
@@ -1,0 +1,1 @@
+-s -r \.go$ -R ^\.go/ -R ^cmd/ -R _test\.go$ make debug-run


### PR DESCRIPTION
### What

Added a local dockerfile that can be used with reflex and docker-compose for local dev environment.
Added reflex file that defines regex for files to be watched.
Added make target that uses `go run` rather than `go build` & run binary

### How to review

Make sure service can still be used as normal.

Test docker-compose Cantabular import journey works as a whole: https://github.com/ONSdigital/dp-compose/pull/13

Part of 5 PRs - Might be best if one person reviews all at once as they are designed to work together.

### Who can review

Anyone - If someone wants to review the whole journey that would be best. Minimum requirement test these changes don't stop the service running as it does as-is
