### PR TITLE
Add cantabular_blob to dimension-import-event

### DIFF
--- a/event/event.go
+++ b/event/event.go
@@ -17,7 +17,8 @@ type CantabularDatasetInstanceStarted struct {
 */
 
 type CategoryDimensionImport struct {
-	JobID       string `avro:"job_id"`
-	InstanceID  string `avro:"instance_id"`
-	DimensionID string `avro:"dimension_id"`
+	JobID          string `avro:"job_id"`
+	InstanceID     string `avro:"instance_id"`
+	DimensionID    string `avro:"dimension_id"`
+	CantabularBlob string `avro:"cantabular_blob"`
 }

--- a/handler/instance_started.go
+++ b/handler/instance_started.go
@@ -120,7 +120,7 @@ func (h *InstanceStarted) Handle(ctx context.Context, e *event.InstanceStarted) 
 
 	log.Info(ctx, "Triggering dimension options import")
 
-	if errs := h.triggerImportDimensionOptions(ctx, codelists, e); len(errs) != 0 {
+	if errs := h.triggerImportDimensionOptions(ctx, r.CantabularBlob, codelists, e); len(errs) != 0 {
 		var errdata []map[string]interface{}
 
 		for _, err := range errs {
@@ -200,7 +200,7 @@ func (h *InstanceStarted) createUpdateInstanceRequest(cb cantabular.Codebook, e 
 	return req
 }
 
-func (h *InstanceStarted) triggerImportDimensionOptions(ctx context.Context, dimensions []string, e *event.InstanceStarted) []error {
+func (h *InstanceStarted) triggerImportDimensionOptions(ctx context.Context, blob string, dimensions []string, e *event.InstanceStarted) []error {
 	var errs []error
 
 	log.Info(ctx, "Triggering dimension-option import process")
@@ -210,6 +210,7 @@ func (h *InstanceStarted) triggerImportDimensionOptions(ctx context.Context, dim
 			DimensionID: d,
 			JobID:       e.JobID,
 			InstanceID:  e.InstanceID,
+			CantabularBlob: blob,
 		}
 
 		s := schema.CategoryDimensionImport

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -12,9 +12,10 @@ var categoryDimensionImport = `{
   "type": "record",
   "name": "cantabular-dataset-instance-started",
   "fields": [
-    {"name": "dimension_id",   "type": "string"},
-    {"name": "job_id", "type": "string"},
-    {"name": "instance_id", "type": "string"}
+    {"name": "dimension_id",    "type": "string"},
+    {"name": "job_id",          "type": "string"},
+    {"name": "instance_id",     "type": "string"},
+    {"name": "cantabular_blob", "type": "string"}
   ]
 }`
 


### PR DESCRIPTION
### What

Added `cantabular_blob` field to the dimension-import event as it was discovered it would be required.

### How to review

Check tests still pass, code makes sense. 
There are no component tests to test the output of the kafka producer yet (that work is part of a parallel PR)

### Who can review

Anyone
