### PR TITLE
replaced Cantabular healthcheck with a placeholder (develop)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -24,6 +24,7 @@ type Config struct {
 	RecipeAPIURL                 string        `envconfig:"RECIPE_API_URL"`
 	ImportAPIURL                 string        `envconfig:"IMPORT_API_URL"`
 	CantabularURL                string        `envconfig:"CANTABULAR_URL"`
+	CantabularHealthcheckEnabled bool          `envconfig:"CANTABULAR_HEALTHCHECK_ENABLED"`
 	ServiceAuthToken             string        `envconfig:"SERVICE_AUTH_TOKEN"         json:"-"`
 	ComponentTestUseLogFile      bool          `envconfig:"COMPONENT_TEST_USE_LOG_FILE"`
 }
@@ -53,6 +54,7 @@ func Get() (*Config, error) {
 		RecipeAPIURL:                 "http://localhost:22300",
 		ImportAPIURL:                 "http://localhost:21800",
 		CantabularURL:                "http://localhost:8491",
+		CantabularHealthcheckEnabled: false,
 		ServiceAuthToken:             "",
 		CategoryDimensionImportTopic: "cantabular-dataset-category-dimension-import",
 		ComponentTestUseLogFile:      false,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -37,6 +37,7 @@ func TestConfig(t *testing.T) {
 				So(cfg.RecipeAPIURL, ShouldEqual, "http://localhost:22300")
 				So(cfg.CantabularURL, ShouldEqual, "http://localhost:8491")
 				So(cfg.ImportAPIURL, ShouldEqual, "http://localhost:21800")
+				So(cfg.CantabularHealthcheckEnabled, ShouldBeFalse)
 				So(cfg.ComponentTestUseLogFile, ShouldEqual, false)
 
 			})

--- a/service/service.go
+++ b/service/service.go
@@ -286,7 +286,13 @@ func (svc *Service) registerCheckers() error {
 		return fmt.Errorf("error adding check for Recipe API Client: %w", err)
 	}
 
-	if err := hc.AddCheck("Cantabular client", svc.cantabularClient.Checker); err != nil {
+	// TODO - when Cantabular server is deployed to Production, remove this placeholder
+	// and use the real Checker instead: svc.cantabularClient.Checker
+	placeholderChecker := func(ctx context.Context, state *healthcheck.CheckState) error {
+		state.Update(healthcheck.StatusOK, "Cantabular healthcheck placeholder", http.StatusOK)
+		return nil
+	}
+	if err := hc.AddCheck("Cantabular client", placeholderChecker); err != nil {
 		return fmt.Errorf("error adding check for Cantabular Client: %w", err)
 	}
 


### PR DESCRIPTION
### What

- Replaced Cantabular healthcheck Checker with a placeholder.
This needs to be done in order to release this service to production, where the Cantabular server is not running yet. Once it is running, we can undo this change.

### How to review

- Make sure code change makes sense
- Make sure unit tests pass
- (info) tested the`/health` endpoint locally and validated that a successful check with the placeholder text appears.

### Who can review

anyone