### PR TITLE
Remove log line that may grow too big. Fix linter issues and a bug.

### DIFF
--- a/cmd/test-consumer/main.go
+++ b/cmd/test-consumer/main.go
@@ -18,19 +18,6 @@ import (
 
 const serviceName = "kafka-example-consumer"
 
-// Config is the kafka configuration for this example
-type Config struct {
-	Brokers                 []string      `envconfig:"KAFKA_ADDR"`
-	KafkaMaxBytes           int           `envconfig:"KAFKA_MAX_BYTES"`
-	KafkaVersion            string        `envconfig:"KAFKA_VERSION"`
-	ConsumedTopic           string        `envconfig:"KAFKA_CONSUMED_TOPIC"`
-	ConsumedGroup           string        `envconfig:"KAFKA_CONSUMED_GROUP"`
-	WaitForConsumerReady    bool          `envconfig:"KAFKA_WAIT_CONSUMER_READY"`
-	GracefulShutdownTimeout time.Duration `envconfig:"GRACEFUL_SHUTDOWN_TIMEOUT"`
-	Snooze                  bool          `envconfig:"SNOOZE"`
-	OverSleep               bool          `envconfig:"OVERSLEEP"`
-}
-
 func main() {
 	log.Namespace = serviceName
 	ctx := context.Background()

--- a/cmd/test-producer/main.go
+++ b/cmd/test-producer/main.go
@@ -22,7 +22,7 @@ func main() {
 	ctx := context.Background()
 
 	// Get Config
-	config, err := config.Get()
+	cfg, err := config.Get()
 	if err != nil {
 		log.Event(ctx, "error getting config", log.FATAL, log.Error(err))
 		os.Exit(1)
@@ -30,11 +30,11 @@ func main() {
 
 	// Create Kafka Producer
 	pChannels := kafka.CreateProducerChannels()
-	kafkaProducer, err := kafka.NewProducer(ctx, config.KafkaAddr, config.InstanceStartedTopic, pChannels, &kafka.ProducerConfig{
-		KafkaVersion: &config.KafkaVersion,
+	kafkaProducer, err := kafka.NewProducer(ctx, cfg.KafkaAddr, cfg.InstanceStartedTopic, pChannels, &kafka.ProducerConfig{
+		KafkaVersion: &cfg.KafkaVersion,
 	})
 	if err != nil {
-		log.Event(ctx, "fatal error trying to create kafka producer", log.FATAL, log.Error(err), log.Data{"topic": config.InstanceStartedTopic})
+		log.Event(ctx, "fatal error trying to create kafka producer", log.FATAL, log.Error(err), log.Data{"topic": cfg.InstanceStartedTopic})
 		os.Exit(1)
 	}
 

--- a/event/consume.go
+++ b/event/consume.go
@@ -25,7 +25,7 @@ func (p *Processor) Consume(ctx context.Context, cg kafka.IConsumerGroup, h Hand
 					return
 				}
 
-				msgCtx, _ := context.WithCancel(ctx)
+				msgCtx, cancel := context.WithCancel(ctx)
 
 				if errs := p.processMessage(msgCtx, msg, h); len(errs) != 0 {
 					var errdata []map[string]interface{}
@@ -44,6 +44,7 @@ func (p *Processor) Consume(ctx context.Context, cg kafka.IConsumerGroup, h Hand
 				}
 
 				msg.Release()
+				cancel()
 			case <-cg.Channels().Closer:
 				log.Info(ctx, "closer channel closed - closing event consumer loop ", log.Data{"worker_id": workerID})
 				return

--- a/event/consume_test.go
+++ b/event/consume_test.go
@@ -20,7 +20,7 @@ import (
 
 var (
 	testCtx    = context.Background()
-	errHandler = errors.New("Handler Error")
+	errHandler = errors.New("handler Error")
 )
 
 var testEvent = event.InstanceStarted{

--- a/event/error.go
+++ b/event/error.go
@@ -1,6 +1,6 @@
 package event
 
-// Error is the handler package's error type. Is not meant to be compared as a
+// Error is the handler package's error type. Is not meant to be compared as
 // a type, but information should be extracted via the interfaces
 // it implements with callback functions. Is not guaranteed to remain exported
 // so shouldn't be treated as such.

--- a/event/event.go
+++ b/event/event.go
@@ -4,7 +4,7 @@ import (
 	"github.com/ONSdigital/dp-import/events"
 )
 
-// InstanceStarted provides an avro structure for a Instance Started event
+// InstanceStarted provides an avro structure for an Instance Started event
 type InstanceStarted events.CantabularDatasetInstanceStarted
 
 /*

--- a/handler/error.go
+++ b/handler/error.go
@@ -1,6 +1,6 @@
 package handler
 
-// Error is the handler package's error type. Is not meant to be compared as a
+// Error is the handler package's error type. Is not meant to be compared as
 // a type, but information should be extracted via the interfaces
 // it implements with callback functions. Is not guaranteed to remain exported
 // so shouldn't be treated as such.

--- a/handler/instance_started.go
+++ b/handler/instance_started.go
@@ -10,8 +10,8 @@ import (
 	"github.com/ONSdigital/dp-import-cantabular-dataset/schema"
 
 	"github.com/ONSdigital/dp-api-clients-go/v2/cantabular"
-	"github.com/ONSdigital/dp-api-clients-go/v2/headers"
 	"github.com/ONSdigital/dp-api-clients-go/v2/dataset"
+	"github.com/ONSdigital/dp-api-clients-go/v2/headers"
 	"github.com/ONSdigital/dp-api-clients-go/v2/recipe"
 	kafka "github.com/ONSdigital/dp-kafka/v2"
 
@@ -41,7 +41,6 @@ func NewInstanceStarted(cfg config.Config, c CantabularClient, r RecipeAPIClient
 	}
 }
 
-// Note to self: why pass cfg rathe than have as part of struct?
 // Handle takes a single event.
 func (h *InstanceStarted) Handle(ctx context.Context, e *event.InstanceStarted) error {
 	ld := log.Data{
@@ -97,7 +96,6 @@ func (h *InstanceStarted) Handle(ctx context.Context, e *event.InstanceStarted) 
 	log.Info(ctx, "Successfully got Codebook", log.Data{
 		"datablob":      resp.Dataset,
 		"num_variables": len(resp.Codebook),
-		"codebook":      resp.Codebook,
 	})
 
 	ireq := h.createUpdateInstanceRequest(resp.Codebook, e, r.CantabularBlob)
@@ -127,7 +125,7 @@ func (h *InstanceStarted) Handle(ctx context.Context, e *event.InstanceStarted) 
 		"num_dimensions": len(codelists),
 	})
 
-	if errs := h.triggerImportDimensionOptions(ctx, r.CantabularBlob, codelists, e); len(errs) != 0 {
+	if errs := h.triggerImportDimensionOptions(r.CantabularBlob, codelists, e); len(errs) != 0 {
 		var errdata []map[string]interface{}
 
 		for _, err := range errs {
@@ -184,7 +182,7 @@ func (h *InstanceStarted) createUpdateInstanceRequest(cb cantabular.Codebook, e 
 		CSVHeader:  []string{cantabularTable},
 		InstanceID: e.InstanceID,
 		Type:       cantabularTable,
-		IsBasedOn:  &dataset.IsBasedOn{
+		IsBasedOn: &dataset.IsBasedOn{
 			ID:   ctblrBlob,
 			Type: cantabularTable,
 		},
@@ -214,7 +212,7 @@ func (h *InstanceStarted) createUpdateInstanceRequest(cb cantabular.Codebook, e 
 	return req
 }
 
-func (h *InstanceStarted) triggerImportDimensionOptions(ctx context.Context, blob string, dimensions []string, e *event.InstanceStarted) []error {
+func (h *InstanceStarted) triggerImportDimensionOptions(blob string, dimensions []string, e *event.InstanceStarted) []error {
 	var errs []error
 
 	for _, d := range dimensions {

--- a/handler/instance_started_test.go
+++ b/handler/instance_started_test.go
@@ -65,12 +65,12 @@ func TestInstanceStartedHandler_HandleHappy(t *testing.T) {
 			defer wg.Done()
 
 			expected := []event.CategoryDimensionImport{
-				event.CategoryDimensionImport{
+				{
 					JobID:       "test-job-id",
 					InstanceID:  "test-instance-id",
 					DimensionID: "test-variable",
 				},
-				event.CategoryDimensionImport{
+				{
 					JobID:       "test-job-id",
 					InstanceID:  "test-instance-id",
 					DimensionID: "test-mapped-variable",
@@ -203,7 +203,7 @@ func testCodebook() cantabular.Codebook {
 				"Code 3",
 			},
 			MapFrom: []cantabular.MapFrom{
-				cantabular.MapFrom{
+				{
 					SourceNames: []string{
 						"test-variable",
 					},
@@ -222,15 +222,15 @@ func testRecipe() *recipe.Recipe {
 	return &recipe.Recipe{
 		ID: "test-recipe-id",
 		OutputInstances: []recipe.Instance{
-			recipe.Instance{
+			{
 				DatasetID: "test-dataset-id",
 				Title:     "Test Instance",
 				CodeLists: []recipe.CodeList{
-					recipe.CodeList{
+					{
 						ID:   "test-variable",
 						Name: "Test Variable",
 					},
-					recipe.CodeList{
+					{
 						ID:   "test-mapped-variable",
 						Name: "Test Mapped Variable",
 					},

--- a/main_test.go
+++ b/main_test.go
@@ -1,11 +1,11 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"io"
 	"os"
 	"testing"
-	"context"
 
 	"github.com/ONSdigital/dp-import-cantabular-dataset/config"
 	"github.com/ONSdigital/dp-import-cantabular-dataset/features/steps"

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -268,7 +268,7 @@ func TestClose(t *testing.T) {
 		producerMock := &kafkatest.IProducerMock{
 			CloseFunc: func(ctx context.Context) error {
 				if consumerListening {
-					return fmt.Errorf("Kafka producer closed while consumer is still listening")
+					return fmt.Errorf("kafka producer closed while consumer is still listening")
 				}
 				return nil
 			},
@@ -283,7 +283,7 @@ func TestClose(t *testing.T) {
 		serverMock := &serviceMock.HTTPServerMock{
 			ShutdownFunc: func(ctx context.Context) error {
 				if !hcStopped {
-					return fmt.Errorf("Server stopped before healthcheck")
+					return fmt.Errorf("server stopped before healthcheck")
 				}
 				return nil
 			},


### PR DESCRIPTION
### What

1. Logging of resp.Codebook removed as it may grow too large.
2. Fix context leak for WithCancel() - called its cancel func.
3. Clear up a number of linter issues.

### How to review

Visual inspection of changes.
Run tests.

### Who can review

Anyone