### PR TITLE
Add ignore ERRO[xxxx] 0 message on component tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ convey:
 test-component:
 	cd features/steps && docker-compose up --build --abort-on-container-exit
 	cd features/steps && docker-compose down --volume
+	echo "please ignore error codes 0, like so: ERRO[xxxx] 0, as error code 0 means that there was no error"
 
 .PHONY: fmt
 fmt:

--- a/README.md
+++ b/README.md
@@ -79,4 +79,3 @@ See [CONTRIBUTING](CONTRIBUTING.md) for details.
 Copyright © 2021, Office for National Statistics (https://www.ons.gov.uk)
 
 Released under MIT license, see [LICENSE](LICENSE.md) for details.
-

--- a/ci/scripts/component.sh
+++ b/ci/scripts/component.sh
@@ -7,3 +7,6 @@ pushd dp-import-cantabular-dataset
   cat $f && rm $f
 popd
 exit $e
+
+# Show message to prevent any confusion by 'ERROR 0' outpout
+echo "please ignore error codes 0, like so: ERRO[xxxx] 0, as error code 0 means that there was no error"


### PR DESCRIPTION
### What

Add ignore ERRO[xxxx] 0 message on component tests

### How to review

Run component tests and validate that you see the message:
```Add ignore ERRO[xxxx] 0 message on component tests```
At the end of a successful run.

### Who can review

anyone (suggested @redhug1 )