### PR TITLE
use dimension id and href from recipe codelists instead of cantabular response

### DIFF
--- a/event/interface.go
+++ b/event/interface.go
@@ -12,7 +12,7 @@ import (
 
 // Handler represents a handler for processing a single event.
 type Handler interface {
-	Handle(context.Context, *InstanceStarted) error
+	Handle(ctx context.Context, instanceStarted *InstanceStarted) error
 }
 
 type coder interface {

--- a/event/mock/dataset_api_client.go
+++ b/event/mock/dataset_api_client.go
@@ -10,91 +10,94 @@ import (
 	"sync"
 )
 
+var (
+	lockDatasetAPIClientMockPutInstanceState sync.RWMutex
+)
+
 // Ensure, that DatasetAPIClientMock does implement event.DatasetAPIClient.
 // If this is not the case, regenerate this file with moq.
 var _ event.DatasetAPIClient = &DatasetAPIClientMock{}
 
 // DatasetAPIClientMock is a mock implementation of event.DatasetAPIClient.
 //
-// 	func TestSomethingThatUsesDatasetAPIClient(t *testing.T) {
+//     func TestSomethingThatUsesDatasetAPIClient(t *testing.T) {
 //
-// 		// make and configure a mocked event.DatasetAPIClient
-// 		mockedDatasetAPIClient := &DatasetAPIClientMock{
-// 			PutInstanceStateFunc: func(contextMoqParam context.Context, s1 string, s2 string, state dataset.State, s3 string) (string, error) {
-// 				panic("mock out the PutInstanceState method")
-// 			},
-// 		}
+//         // make and configure a mocked event.DatasetAPIClient
+//         mockedDatasetAPIClient := &DatasetAPIClientMock{
+//             PutInstanceStateFunc: func(in1 context.Context, in2 string, in3 string, in4 dataset.State, in5 string) (string, error) {
+// 	               panic("mock out the PutInstanceState method")
+//             },
+//         }
 //
-// 		// use mockedDatasetAPIClient in code that requires event.DatasetAPIClient
-// 		// and then make assertions.
+//         // use mockedDatasetAPIClient in code that requires event.DatasetAPIClient
+//         // and then make assertions.
 //
-// 	}
+//     }
 type DatasetAPIClientMock struct {
 	// PutInstanceStateFunc mocks the PutInstanceState method.
-	PutInstanceStateFunc func(contextMoqParam context.Context, s1 string, s2 string, state dataset.State, s3 string) (string, error)
+	PutInstanceStateFunc func(in1 context.Context, in2 string, in3 string, in4 dataset.State, in5 string) (string, error)
 
 	// calls tracks calls to the methods.
 	calls struct {
 		// PutInstanceState holds details about calls to the PutInstanceState method.
 		PutInstanceState []struct {
-			// ContextMoqParam is the contextMoqParam argument value.
-			ContextMoqParam context.Context
-			// S1 is the s1 argument value.
-			S1 string
-			// S2 is the s2 argument value.
-			S2 string
-			// State is the state argument value.
-			State dataset.State
-			// S3 is the s3 argument value.
-			S3 string
+			// In1 is the in1 argument value.
+			In1 context.Context
+			// In2 is the in2 argument value.
+			In2 string
+			// In3 is the in3 argument value.
+			In3 string
+			// In4 is the in4 argument value.
+			In4 dataset.State
+			// In5 is the in5 argument value.
+			In5 string
 		}
 	}
-	lockPutInstanceState sync.RWMutex
 }
 
 // PutInstanceState calls PutInstanceStateFunc.
-func (mock *DatasetAPIClientMock) PutInstanceState(contextMoqParam context.Context, s1 string, s2 string, state dataset.State, s3 string) (string, error) {
+func (mock *DatasetAPIClientMock) PutInstanceState(in1 context.Context, in2 string, in3 string, in4 dataset.State, in5 string) (string, error) {
 	if mock.PutInstanceStateFunc == nil {
 		panic("DatasetAPIClientMock.PutInstanceStateFunc: method is nil but DatasetAPIClient.PutInstanceState was just called")
 	}
 	callInfo := struct {
-		ContextMoqParam context.Context
-		S1              string
-		S2              string
-		State           dataset.State
-		S3              string
+		In1 context.Context
+		In2 string
+		In3 string
+		In4 dataset.State
+		In5 string
 	}{
-		ContextMoqParam: contextMoqParam,
-		S1:              s1,
-		S2:              s2,
-		State:           state,
-		S3:              s3,
+		In1: in1,
+		In2: in2,
+		In3: in3,
+		In4: in4,
+		In5: in5,
 	}
-	mock.lockPutInstanceState.Lock()
+	lockDatasetAPIClientMockPutInstanceState.Lock()
 	mock.calls.PutInstanceState = append(mock.calls.PutInstanceState, callInfo)
-	mock.lockPutInstanceState.Unlock()
-	return mock.PutInstanceStateFunc(contextMoqParam, s1, s2, state, s3)
+	lockDatasetAPIClientMockPutInstanceState.Unlock()
+	return mock.PutInstanceStateFunc(in1, in2, in3, in4, in5)
 }
 
 // PutInstanceStateCalls gets all the calls that were made to PutInstanceState.
 // Check the length with:
 //     len(mockedDatasetAPIClient.PutInstanceStateCalls())
 func (mock *DatasetAPIClientMock) PutInstanceStateCalls() []struct {
-	ContextMoqParam context.Context
-	S1              string
-	S2              string
-	State           dataset.State
-	S3              string
+	In1 context.Context
+	In2 string
+	In3 string
+	In4 dataset.State
+	In5 string
 } {
 	var calls []struct {
-		ContextMoqParam context.Context
-		S1              string
-		S2              string
-		State           dataset.State
-		S3              string
+		In1 context.Context
+		In2 string
+		In3 string
+		In4 dataset.State
+		In5 string
 	}
-	mock.lockPutInstanceState.RLock()
+	lockDatasetAPIClientMockPutInstanceState.RLock()
 	calls = mock.calls.PutInstanceState
-	mock.lockPutInstanceState.RUnlock()
+	lockDatasetAPIClientMockPutInstanceState.RUnlock()
 	return calls
 }

--- a/event/mock/handler.go
+++ b/event/mock/handler.go
@@ -9,73 +9,76 @@ import (
 	"sync"
 )
 
+var (
+	lockHandlerMockHandle sync.RWMutex
+)
+
 // Ensure, that HandlerMock does implement event.Handler.
 // If this is not the case, regenerate this file with moq.
 var _ event.Handler = &HandlerMock{}
 
 // HandlerMock is a mock implementation of event.Handler.
 //
-// 	func TestSomethingThatUsesHandler(t *testing.T) {
+//     func TestSomethingThatUsesHandler(t *testing.T) {
 //
-// 		// make and configure a mocked event.Handler
-// 		mockedHandler := &HandlerMock{
-// 			HandleFunc: func(contextMoqParam context.Context, instanceStarted *event.InstanceStarted) error {
-// 				panic("mock out the Handle method")
-// 			},
-// 		}
+//         // make and configure a mocked event.Handler
+//         mockedHandler := &HandlerMock{
+//             HandleFunc: func(ctx context.Context, instanceStarted *event.InstanceStarted) error {
+// 	               panic("mock out the Handle method")
+//             },
+//         }
 //
-// 		// use mockedHandler in code that requires event.Handler
-// 		// and then make assertions.
+//         // use mockedHandler in code that requires event.Handler
+//         // and then make assertions.
 //
-// 	}
+//     }
 type HandlerMock struct {
 	// HandleFunc mocks the Handle method.
-	HandleFunc func(contextMoqParam context.Context, instanceStarted *event.InstanceStarted) error
+	HandleFunc func(ctx context.Context, instanceStarted *event.InstanceStarted) error
 
 	// calls tracks calls to the methods.
 	calls struct {
 		// Handle holds details about calls to the Handle method.
 		Handle []struct {
-			// ContextMoqParam is the contextMoqParam argument value.
-			ContextMoqParam context.Context
+			// Ctx is the ctx argument value.
+			Ctx context.Context
 			// InstanceStarted is the instanceStarted argument value.
 			InstanceStarted *event.InstanceStarted
 		}
 	}
-	lockHandle sync.RWMutex
 }
 
 // Handle calls HandleFunc.
-func (mock *HandlerMock) Handle(contextMoqParam context.Context, instanceStarted *event.InstanceStarted) error {
+func (mock *HandlerMock) Handle(ctx context.Context, instanceStarted *event.InstanceStarted) error {
 	if mock.HandleFunc == nil {
 		panic("HandlerMock.HandleFunc: method is nil but Handler.Handle was just called")
 	}
 	callInfo := struct {
-		ContextMoqParam context.Context
+		Ctx             context.Context
 		InstanceStarted *event.InstanceStarted
 	}{
-		ContextMoqParam: contextMoqParam,
+		Ctx:             ctx,
 		InstanceStarted: instanceStarted,
 	}
-	mock.lockHandle.Lock()
+	lockHandlerMockHandle.Lock()
 	mock.calls.Handle = append(mock.calls.Handle, callInfo)
-	mock.lockHandle.Unlock()
-	return mock.HandleFunc(contextMoqParam, instanceStarted)
+	lockHandlerMockHandle.Unlock()
+	return mock.HandleFunc(ctx, instanceStarted)
 }
 
 // HandleCalls gets all the calls that were made to Handle.
 // Check the length with:
 //     len(mockedHandler.HandleCalls())
 func (mock *HandlerMock) HandleCalls() []struct {
-	ContextMoqParam context.Context
+	Ctx             context.Context
 	InstanceStarted *event.InstanceStarted
 } {
 	var calls []struct {
-		ContextMoqParam context.Context
+		Ctx             context.Context
 		InstanceStarted *event.InstanceStarted
 	}
-	mock.lockHandle.RLock()
+	lockHandlerMockHandle.RLock()
 	calls = mock.calls.Handle
-	mock.lockHandle.RUnlock()
+	lockHandlerMockHandle.RUnlock()
 	return calls
 }

--- a/event/mock/import_api_client.go
+++ b/event/mock/import_api_client.go
@@ -9,85 +9,88 @@ import (
 	"sync"
 )
 
+var (
+	lockImportAPIClientMockUpdateImportJobState sync.RWMutex
+)
+
 // Ensure, that ImportAPIClientMock does implement event.ImportAPIClient.
 // If this is not the case, regenerate this file with moq.
 var _ event.ImportAPIClient = &ImportAPIClientMock{}
 
 // ImportAPIClientMock is a mock implementation of event.ImportAPIClient.
 //
-// 	func TestSomethingThatUsesImportAPIClient(t *testing.T) {
+//     func TestSomethingThatUsesImportAPIClient(t *testing.T) {
 //
-// 		// make and configure a mocked event.ImportAPIClient
-// 		mockedImportAPIClient := &ImportAPIClientMock{
-// 			UpdateImportJobStateFunc: func(contextMoqParam context.Context, s1 string, s2 string, s3 string) error {
-// 				panic("mock out the UpdateImportJobState method")
-// 			},
-// 		}
+//         // make and configure a mocked event.ImportAPIClient
+//         mockedImportAPIClient := &ImportAPIClientMock{
+//             UpdateImportJobStateFunc: func(in1 context.Context, in2 string, in3 string, in4 string) error {
+// 	               panic("mock out the UpdateImportJobState method")
+//             },
+//         }
 //
-// 		// use mockedImportAPIClient in code that requires event.ImportAPIClient
-// 		// and then make assertions.
+//         // use mockedImportAPIClient in code that requires event.ImportAPIClient
+//         // and then make assertions.
 //
-// 	}
+//     }
 type ImportAPIClientMock struct {
 	// UpdateImportJobStateFunc mocks the UpdateImportJobState method.
-	UpdateImportJobStateFunc func(contextMoqParam context.Context, s1 string, s2 string, s3 string) error
+	UpdateImportJobStateFunc func(in1 context.Context, in2 string, in3 string, in4 string) error
 
 	// calls tracks calls to the methods.
 	calls struct {
 		// UpdateImportJobState holds details about calls to the UpdateImportJobState method.
 		UpdateImportJobState []struct {
-			// ContextMoqParam is the contextMoqParam argument value.
-			ContextMoqParam context.Context
-			// S1 is the s1 argument value.
-			S1 string
-			// S2 is the s2 argument value.
-			S2 string
-			// S3 is the s3 argument value.
-			S3 string
+			// In1 is the in1 argument value.
+			In1 context.Context
+			// In2 is the in2 argument value.
+			In2 string
+			// In3 is the in3 argument value.
+			In3 string
+			// In4 is the in4 argument value.
+			In4 string
 		}
 	}
-	lockUpdateImportJobState sync.RWMutex
 }
 
 // UpdateImportJobState calls UpdateImportJobStateFunc.
-func (mock *ImportAPIClientMock) UpdateImportJobState(contextMoqParam context.Context, s1 string, s2 string, s3 string) error {
+func (mock *ImportAPIClientMock) UpdateImportJobState(in1 context.Context, in2 string, in3 string, in4 string) error {
 	if mock.UpdateImportJobStateFunc == nil {
 		panic("ImportAPIClientMock.UpdateImportJobStateFunc: method is nil but ImportAPIClient.UpdateImportJobState was just called")
 	}
 	callInfo := struct {
-		ContextMoqParam context.Context
-		S1              string
-		S2              string
-		S3              string
+		In1 context.Context
+		In2 string
+		In3 string
+		In4 string
 	}{
-		ContextMoqParam: contextMoqParam,
-		S1:              s1,
-		S2:              s2,
-		S3:              s3,
+		In1: in1,
+		In2: in2,
+		In3: in3,
+		In4: in4,
 	}
-	mock.lockUpdateImportJobState.Lock()
+	lockImportAPIClientMockUpdateImportJobState.Lock()
 	mock.calls.UpdateImportJobState = append(mock.calls.UpdateImportJobState, callInfo)
-	mock.lockUpdateImportJobState.Unlock()
-	return mock.UpdateImportJobStateFunc(contextMoqParam, s1, s2, s3)
+	lockImportAPIClientMockUpdateImportJobState.Unlock()
+	return mock.UpdateImportJobStateFunc(in1, in2, in3, in4)
 }
 
 // UpdateImportJobStateCalls gets all the calls that were made to UpdateImportJobState.
 // Check the length with:
 //     len(mockedImportAPIClient.UpdateImportJobStateCalls())
 func (mock *ImportAPIClientMock) UpdateImportJobStateCalls() []struct {
-	ContextMoqParam context.Context
-	S1              string
-	S2              string
-	S3              string
+	In1 context.Context
+	In2 string
+	In3 string
+	In4 string
 } {
 	var calls []struct {
-		ContextMoqParam context.Context
-		S1              string
-		S2              string
-		S3              string
+		In1 context.Context
+		In2 string
+		In3 string
+		In4 string
 	}
-	mock.lockUpdateImportJobState.RLock()
+	lockImportAPIClientMockUpdateImportJobState.RLock()
 	calls = mock.calls.UpdateImportJobState
-	mock.lockUpdateImportJobState.RUnlock()
+	lockImportAPIClientMockUpdateImportJobState.RUnlock()
 	return calls
 }

--- a/features/consuming-instance-started-event.feature
+++ b/features/consuming-instance-started-event.feature
@@ -149,6 +149,7 @@ Feature: Import-Cantabular-Dataset
       }
       """
 
+    And no recipe with id "2peofjdkm" is available from dp-recipe-api
     And the call to update instance "instance-happy-01" is succesful
     And the call to update job "job-happy-01" is succesful
 
@@ -165,7 +166,7 @@ Feature: Import-Cantabular-Dataset
       }
       """
 
-    And the call to update instance "instance-happy-01" is succesful
+    And the call to update instance "03wiroefld" is unsuccesful
     And the call to update job "job-happy-01" is succesful
 
     Then no category dimension import events should be produced

--- a/features/steps/steps.go
+++ b/features/steps/steps.go
@@ -20,6 +20,7 @@ import (
 
 func (c *Component) RegisterSteps(ctx *godog.ScenarioContext) {
 	ctx.Step(`^the following recipe with id "([^"]*)" is available from dp-recipe-api:$`, c.theFollowingRecipeIsAvailable)
+	ctx.Step(`^no recipe with id "([^"]*)" is available from dp-recipe-api`, c.theFollowingRecipeIsNotFound)
 	ctx.Step(`^the following response is available from Cantabular from the codebook "([^"]*)" and query "([^"]*)":$`, c.theFollowingCodebookIsAvailable)
 
 	ctx.Step(`^the call to update job "([^"]*)" is succesful`, c.theCallToUpdateJobIsSuccessful)
@@ -37,6 +38,14 @@ func (c *Component) theFollowingRecipeIsAvailable(id string, recipe *godog.DocSt
 		Get("/recipes/" + id).
 		Reply(http.StatusOK).
 		BodyString(recipe.Content)
+
+	return nil
+}
+
+func (c *Component) theFollowingRecipeIsNotFound(id string) error {
+	c.RecipeAPI.NewHandler().
+		Get("/recipes/" + id).
+		Reply(http.StatusNotFound)
 
 	return nil
 }

--- a/handler/instance_started.go
+++ b/handler/instance_started.go
@@ -209,10 +209,10 @@ func (h *InstanceStarted) createUpdateInstanceRequest(cb cantabular.Codebook, e 
 
 		// id and url values overwritten by codelist values.
 		// Note that cantabular codebook is sorted with exactly the same order as codelists array.
-		if len(codelists[i].ID) > 0 {
+		if codelists[i].ID != "" {
 			id = codelists[i].ID
 		}
-		if len(codelists[i].HRef) > 0 {
+		if codelists[i].ID != "" {
 			url = codelists[i].HRef
 		}
 

--- a/handler/interface.go
+++ b/handler/interface.go
@@ -17,8 +17,8 @@ type CantabularClient interface {
 }
 
 type DatasetAPIClient interface {
-	PutInstance(context.Context, string, string, string, string, dataset.UpdateInstance, string) (string, error)
-	PutInstanceState(context.Context, string, string, dataset.State, string) (string, error)
+	PutInstance(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, instanceID string, i dataset.UpdateInstance, ifMatch string) (eTag string, err error)
+	PutInstanceState(ctx context.Context, serviceAuthToken, instanceID string, state dataset.State, ifMatch string) (eTag string, err error)
 }
 
 type RecipeAPIClient interface {

--- a/handler/mock/cantabular_client.go
+++ b/handler/mock/cantabular_client.go
@@ -10,73 +10,76 @@ import (
 	"sync"
 )
 
+var (
+	lockCantabularClientMockGetCodebook sync.RWMutex
+)
+
 // Ensure, that CantabularClientMock does implement handler.CantabularClient.
 // If this is not the case, regenerate this file with moq.
 var _ handler.CantabularClient = &CantabularClientMock{}
 
 // CantabularClientMock is a mock implementation of handler.CantabularClient.
 //
-// 	func TestSomethingThatUsesCantabularClient(t *testing.T) {
+//     func TestSomethingThatUsesCantabularClient(t *testing.T) {
 //
-// 		// make and configure a mocked handler.CantabularClient
-// 		mockedCantabularClient := &CantabularClientMock{
-// 			GetCodebookFunc: func(contextMoqParam context.Context, getCodebookRequest cantabular.GetCodebookRequest) (*cantabular.GetCodebookResponse, error) {
-// 				panic("mock out the GetCodebook method")
-// 			},
-// 		}
+//         // make and configure a mocked handler.CantabularClient
+//         mockedCantabularClient := &CantabularClientMock{
+//             GetCodebookFunc: func(in1 context.Context, in2 cantabular.GetCodebookRequest) (*cantabular.GetCodebookResponse, error) {
+// 	               panic("mock out the GetCodebook method")
+//             },
+//         }
 //
-// 		// use mockedCantabularClient in code that requires handler.CantabularClient
-// 		// and then make assertions.
+//         // use mockedCantabularClient in code that requires handler.CantabularClient
+//         // and then make assertions.
 //
-// 	}
+//     }
 type CantabularClientMock struct {
 	// GetCodebookFunc mocks the GetCodebook method.
-	GetCodebookFunc func(contextMoqParam context.Context, getCodebookRequest cantabular.GetCodebookRequest) (*cantabular.GetCodebookResponse, error)
+	GetCodebookFunc func(in1 context.Context, in2 cantabular.GetCodebookRequest) (*cantabular.GetCodebookResponse, error)
 
 	// calls tracks calls to the methods.
 	calls struct {
 		// GetCodebook holds details about calls to the GetCodebook method.
 		GetCodebook []struct {
-			// ContextMoqParam is the contextMoqParam argument value.
-			ContextMoqParam context.Context
-			// GetCodebookRequest is the getCodebookRequest argument value.
-			GetCodebookRequest cantabular.GetCodebookRequest
+			// In1 is the in1 argument value.
+			In1 context.Context
+			// In2 is the in2 argument value.
+			In2 cantabular.GetCodebookRequest
 		}
 	}
-	lockGetCodebook sync.RWMutex
 }
 
 // GetCodebook calls GetCodebookFunc.
-func (mock *CantabularClientMock) GetCodebook(contextMoqParam context.Context, getCodebookRequest cantabular.GetCodebookRequest) (*cantabular.GetCodebookResponse, error) {
+func (mock *CantabularClientMock) GetCodebook(in1 context.Context, in2 cantabular.GetCodebookRequest) (*cantabular.GetCodebookResponse, error) {
 	if mock.GetCodebookFunc == nil {
 		panic("CantabularClientMock.GetCodebookFunc: method is nil but CantabularClient.GetCodebook was just called")
 	}
 	callInfo := struct {
-		ContextMoqParam    context.Context
-		GetCodebookRequest cantabular.GetCodebookRequest
+		In1 context.Context
+		In2 cantabular.GetCodebookRequest
 	}{
-		ContextMoqParam:    contextMoqParam,
-		GetCodebookRequest: getCodebookRequest,
+		In1: in1,
+		In2: in2,
 	}
-	mock.lockGetCodebook.Lock()
+	lockCantabularClientMockGetCodebook.Lock()
 	mock.calls.GetCodebook = append(mock.calls.GetCodebook, callInfo)
-	mock.lockGetCodebook.Unlock()
-	return mock.GetCodebookFunc(contextMoqParam, getCodebookRequest)
+	lockCantabularClientMockGetCodebook.Unlock()
+	return mock.GetCodebookFunc(in1, in2)
 }
 
 // GetCodebookCalls gets all the calls that were made to GetCodebook.
 // Check the length with:
 //     len(mockedCantabularClient.GetCodebookCalls())
 func (mock *CantabularClientMock) GetCodebookCalls() []struct {
-	ContextMoqParam    context.Context
-	GetCodebookRequest cantabular.GetCodebookRequest
+	In1 context.Context
+	In2 cantabular.GetCodebookRequest
 } {
 	var calls []struct {
-		ContextMoqParam    context.Context
-		GetCodebookRequest cantabular.GetCodebookRequest
+		In1 context.Context
+		In2 cantabular.GetCodebookRequest
 	}
-	mock.lockGetCodebook.RLock()
+	lockCantabularClientMockGetCodebook.RLock()
 	calls = mock.calls.GetCodebook
-	mock.lockGetCodebook.RUnlock()
+	lockCantabularClientMockGetCodebook.RUnlock()
 	return calls
 }

--- a/handler/mock/dataset_api_client.go
+++ b/handler/mock/dataset_api_client.go
@@ -10,170 +10,173 @@ import (
 	"sync"
 )
 
+var (
+	lockDatasetAPIClientMockPutInstance      sync.RWMutex
+	lockDatasetAPIClientMockPutInstanceState sync.RWMutex
+)
+
 // Ensure, that DatasetAPIClientMock does implement handler.DatasetAPIClient.
 // If this is not the case, regenerate this file with moq.
 var _ handler.DatasetAPIClient = &DatasetAPIClientMock{}
 
 // DatasetAPIClientMock is a mock implementation of handler.DatasetAPIClient.
 //
-// 	func TestSomethingThatUsesDatasetAPIClient(t *testing.T) {
+//     func TestSomethingThatUsesDatasetAPIClient(t *testing.T) {
 //
-// 		// make and configure a mocked handler.DatasetAPIClient
-// 		mockedDatasetAPIClient := &DatasetAPIClientMock{
-// 			PutInstanceFunc: func(contextMoqParam context.Context, s1 string, s2 string, s3 string, s4 string, updateInstance dataset.UpdateInstance, s5 string) (string, error) {
-// 				panic("mock out the PutInstance method")
-// 			},
-// 			PutInstanceStateFunc: func(contextMoqParam context.Context, s1 string, s2 string, state dataset.State, s3 string) (string, error) {
-// 				panic("mock out the PutInstanceState method")
-// 			},
-// 		}
+//         // make and configure a mocked handler.DatasetAPIClient
+//         mockedDatasetAPIClient := &DatasetAPIClientMock{
+//             PutInstanceFunc: func(ctx context.Context, userAuthToken string, serviceAuthToken string, collectionID string, instanceID string, i dataset.UpdateInstance, ifMatch string) (string, error) {
+// 	               panic("mock out the PutInstance method")
+//             },
+//             PutInstanceStateFunc: func(ctx context.Context, serviceAuthToken string, instanceID string, state dataset.State, ifMatch string) (string, error) {
+// 	               panic("mock out the PutInstanceState method")
+//             },
+//         }
 //
-// 		// use mockedDatasetAPIClient in code that requires handler.DatasetAPIClient
-// 		// and then make assertions.
+//         // use mockedDatasetAPIClient in code that requires handler.DatasetAPIClient
+//         // and then make assertions.
 //
-// 	}
+//     }
 type DatasetAPIClientMock struct {
 	// PutInstanceFunc mocks the PutInstance method.
-	PutInstanceFunc func(contextMoqParam context.Context, s1 string, s2 string, s3 string, s4 string, updateInstance dataset.UpdateInstance, s5 string) (string, error)
+	PutInstanceFunc func(ctx context.Context, userAuthToken string, serviceAuthToken string, collectionID string, instanceID string, i dataset.UpdateInstance, ifMatch string) (string, error)
 
 	// PutInstanceStateFunc mocks the PutInstanceState method.
-	PutInstanceStateFunc func(contextMoqParam context.Context, s1 string, s2 string, state dataset.State, s3 string) (string, error)
+	PutInstanceStateFunc func(ctx context.Context, serviceAuthToken string, instanceID string, state dataset.State, ifMatch string) (string, error)
 
 	// calls tracks calls to the methods.
 	calls struct {
 		// PutInstance holds details about calls to the PutInstance method.
 		PutInstance []struct {
-			// ContextMoqParam is the contextMoqParam argument value.
-			ContextMoqParam context.Context
-			// S1 is the s1 argument value.
-			S1 string
-			// S2 is the s2 argument value.
-			S2 string
-			// S3 is the s3 argument value.
-			S3 string
-			// S4 is the s4 argument value.
-			S4 string
-			// UpdateInstance is the updateInstance argument value.
-			UpdateInstance dataset.UpdateInstance
-			// S5 is the s5 argument value.
-			S5 string
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// UserAuthToken is the userAuthToken argument value.
+			UserAuthToken string
+			// ServiceAuthToken is the serviceAuthToken argument value.
+			ServiceAuthToken string
+			// CollectionID is the collectionID argument value.
+			CollectionID string
+			// InstanceID is the instanceID argument value.
+			InstanceID string
+			// I is the i argument value.
+			I dataset.UpdateInstance
+			// IfMatch is the ifMatch argument value.
+			IfMatch string
 		}
 		// PutInstanceState holds details about calls to the PutInstanceState method.
 		PutInstanceState []struct {
-			// ContextMoqParam is the contextMoqParam argument value.
-			ContextMoqParam context.Context
-			// S1 is the s1 argument value.
-			S1 string
-			// S2 is the s2 argument value.
-			S2 string
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// ServiceAuthToken is the serviceAuthToken argument value.
+			ServiceAuthToken string
+			// InstanceID is the instanceID argument value.
+			InstanceID string
 			// State is the state argument value.
 			State dataset.State
-			// S3 is the s3 argument value.
-			S3 string
+			// IfMatch is the ifMatch argument value.
+			IfMatch string
 		}
 	}
-	lockPutInstance      sync.RWMutex
-	lockPutInstanceState sync.RWMutex
 }
 
 // PutInstance calls PutInstanceFunc.
-func (mock *DatasetAPIClientMock) PutInstance(contextMoqParam context.Context, s1 string, s2 string, s3 string, s4 string, updateInstance dataset.UpdateInstance, s5 string) (string, error) {
+func (mock *DatasetAPIClientMock) PutInstance(ctx context.Context, userAuthToken string, serviceAuthToken string, collectionID string, instanceID string, i dataset.UpdateInstance, ifMatch string) (string, error) {
 	if mock.PutInstanceFunc == nil {
 		panic("DatasetAPIClientMock.PutInstanceFunc: method is nil but DatasetAPIClient.PutInstance was just called")
 	}
 	callInfo := struct {
-		ContextMoqParam context.Context
-		S1              string
-		S2              string
-		S3              string
-		S4              string
-		UpdateInstance  dataset.UpdateInstance
-		S5              string
+		Ctx              context.Context
+		UserAuthToken    string
+		ServiceAuthToken string
+		CollectionID     string
+		InstanceID       string
+		I                dataset.UpdateInstance
+		IfMatch          string
 	}{
-		ContextMoqParam: contextMoqParam,
-		S1:              s1,
-		S2:              s2,
-		S3:              s3,
-		S4:              s4,
-		UpdateInstance:  updateInstance,
-		S5:              s5,
+		Ctx:              ctx,
+		UserAuthToken:    userAuthToken,
+		ServiceAuthToken: serviceAuthToken,
+		CollectionID:     collectionID,
+		InstanceID:       instanceID,
+		I:                i,
+		IfMatch:          ifMatch,
 	}
-	mock.lockPutInstance.Lock()
+	lockDatasetAPIClientMockPutInstance.Lock()
 	mock.calls.PutInstance = append(mock.calls.PutInstance, callInfo)
-	mock.lockPutInstance.Unlock()
-	return mock.PutInstanceFunc(contextMoqParam, s1, s2, s3, s4, updateInstance, s5)
+	lockDatasetAPIClientMockPutInstance.Unlock()
+	return mock.PutInstanceFunc(ctx, userAuthToken, serviceAuthToken, collectionID, instanceID, i, ifMatch)
 }
 
 // PutInstanceCalls gets all the calls that were made to PutInstance.
 // Check the length with:
 //     len(mockedDatasetAPIClient.PutInstanceCalls())
 func (mock *DatasetAPIClientMock) PutInstanceCalls() []struct {
-	ContextMoqParam context.Context
-	S1              string
-	S2              string
-	S3              string
-	S4              string
-	UpdateInstance  dataset.UpdateInstance
-	S5              string
+	Ctx              context.Context
+	UserAuthToken    string
+	ServiceAuthToken string
+	CollectionID     string
+	InstanceID       string
+	I                dataset.UpdateInstance
+	IfMatch          string
 } {
 	var calls []struct {
-		ContextMoqParam context.Context
-		S1              string
-		S2              string
-		S3              string
-		S4              string
-		UpdateInstance  dataset.UpdateInstance
-		S5              string
+		Ctx              context.Context
+		UserAuthToken    string
+		ServiceAuthToken string
+		CollectionID     string
+		InstanceID       string
+		I                dataset.UpdateInstance
+		IfMatch          string
 	}
-	mock.lockPutInstance.RLock()
+	lockDatasetAPIClientMockPutInstance.RLock()
 	calls = mock.calls.PutInstance
-	mock.lockPutInstance.RUnlock()
+	lockDatasetAPIClientMockPutInstance.RUnlock()
 	return calls
 }
 
 // PutInstanceState calls PutInstanceStateFunc.
-func (mock *DatasetAPIClientMock) PutInstanceState(contextMoqParam context.Context, s1 string, s2 string, state dataset.State, s3 string) (string, error) {
+func (mock *DatasetAPIClientMock) PutInstanceState(ctx context.Context, serviceAuthToken string, instanceID string, state dataset.State, ifMatch string) (string, error) {
 	if mock.PutInstanceStateFunc == nil {
 		panic("DatasetAPIClientMock.PutInstanceStateFunc: method is nil but DatasetAPIClient.PutInstanceState was just called")
 	}
 	callInfo := struct {
-		ContextMoqParam context.Context
-		S1              string
-		S2              string
-		State           dataset.State
-		S3              string
+		Ctx              context.Context
+		ServiceAuthToken string
+		InstanceID       string
+		State            dataset.State
+		IfMatch          string
 	}{
-		ContextMoqParam: contextMoqParam,
-		S1:              s1,
-		S2:              s2,
-		State:           state,
-		S3:              s3,
+		Ctx:              ctx,
+		ServiceAuthToken: serviceAuthToken,
+		InstanceID:       instanceID,
+		State:            state,
+		IfMatch:          ifMatch,
 	}
-	mock.lockPutInstanceState.Lock()
+	lockDatasetAPIClientMockPutInstanceState.Lock()
 	mock.calls.PutInstanceState = append(mock.calls.PutInstanceState, callInfo)
-	mock.lockPutInstanceState.Unlock()
-	return mock.PutInstanceStateFunc(contextMoqParam, s1, s2, state, s3)
+	lockDatasetAPIClientMockPutInstanceState.Unlock()
+	return mock.PutInstanceStateFunc(ctx, serviceAuthToken, instanceID, state, ifMatch)
 }
 
 // PutInstanceStateCalls gets all the calls that were made to PutInstanceState.
 // Check the length with:
 //     len(mockedDatasetAPIClient.PutInstanceStateCalls())
 func (mock *DatasetAPIClientMock) PutInstanceStateCalls() []struct {
-	ContextMoqParam context.Context
-	S1              string
-	S2              string
-	State           dataset.State
-	S3              string
+	Ctx              context.Context
+	ServiceAuthToken string
+	InstanceID       string
+	State            dataset.State
+	IfMatch          string
 } {
 	var calls []struct {
-		ContextMoqParam context.Context
-		S1              string
-		S2              string
-		State           dataset.State
-		S3              string
+		Ctx              context.Context
+		ServiceAuthToken string
+		InstanceID       string
+		State            dataset.State
+		IfMatch          string
 	}
-	mock.lockPutInstanceState.RLock()
+	lockDatasetAPIClientMockPutInstanceState.RLock()
 	calls = mock.calls.PutInstanceState
-	mock.lockPutInstanceState.RUnlock()
+	lockDatasetAPIClientMockPutInstanceState.RUnlock()
 	return calls
 }

--- a/handler/mock/recipe_api_client.go
+++ b/handler/mock/recipe_api_client.go
@@ -10,85 +10,88 @@ import (
 	"sync"
 )
 
+var (
+	lockRecipeAPIClientMockGetRecipe sync.RWMutex
+)
+
 // Ensure, that RecipeAPIClientMock does implement handler.RecipeAPIClient.
 // If this is not the case, regenerate this file with moq.
 var _ handler.RecipeAPIClient = &RecipeAPIClientMock{}
 
 // RecipeAPIClientMock is a mock implementation of handler.RecipeAPIClient.
 //
-// 	func TestSomethingThatUsesRecipeAPIClient(t *testing.T) {
+//     func TestSomethingThatUsesRecipeAPIClient(t *testing.T) {
 //
-// 		// make and configure a mocked handler.RecipeAPIClient
-// 		mockedRecipeAPIClient := &RecipeAPIClientMock{
-// 			GetRecipeFunc: func(contextMoqParam context.Context, s1 string, s2 string, s3 string) (*recipe.Recipe, error) {
-// 				panic("mock out the GetRecipe method")
-// 			},
-// 		}
+//         // make and configure a mocked handler.RecipeAPIClient
+//         mockedRecipeAPIClient := &RecipeAPIClientMock{
+//             GetRecipeFunc: func(in1 context.Context, in2 string, in3 string, in4 string) (*recipe.Recipe, error) {
+// 	               panic("mock out the GetRecipe method")
+//             },
+//         }
 //
-// 		// use mockedRecipeAPIClient in code that requires handler.RecipeAPIClient
-// 		// and then make assertions.
+//         // use mockedRecipeAPIClient in code that requires handler.RecipeAPIClient
+//         // and then make assertions.
 //
-// 	}
+//     }
 type RecipeAPIClientMock struct {
 	// GetRecipeFunc mocks the GetRecipe method.
-	GetRecipeFunc func(contextMoqParam context.Context, s1 string, s2 string, s3 string) (*recipe.Recipe, error)
+	GetRecipeFunc func(in1 context.Context, in2 string, in3 string, in4 string) (*recipe.Recipe, error)
 
 	// calls tracks calls to the methods.
 	calls struct {
 		// GetRecipe holds details about calls to the GetRecipe method.
 		GetRecipe []struct {
-			// ContextMoqParam is the contextMoqParam argument value.
-			ContextMoqParam context.Context
-			// S1 is the s1 argument value.
-			S1 string
-			// S2 is the s2 argument value.
-			S2 string
-			// S3 is the s3 argument value.
-			S3 string
+			// In1 is the in1 argument value.
+			In1 context.Context
+			// In2 is the in2 argument value.
+			In2 string
+			// In3 is the in3 argument value.
+			In3 string
+			// In4 is the in4 argument value.
+			In4 string
 		}
 	}
-	lockGetRecipe sync.RWMutex
 }
 
 // GetRecipe calls GetRecipeFunc.
-func (mock *RecipeAPIClientMock) GetRecipe(contextMoqParam context.Context, s1 string, s2 string, s3 string) (*recipe.Recipe, error) {
+func (mock *RecipeAPIClientMock) GetRecipe(in1 context.Context, in2 string, in3 string, in4 string) (*recipe.Recipe, error) {
 	if mock.GetRecipeFunc == nil {
 		panic("RecipeAPIClientMock.GetRecipeFunc: method is nil but RecipeAPIClient.GetRecipe was just called")
 	}
 	callInfo := struct {
-		ContextMoqParam context.Context
-		S1              string
-		S2              string
-		S3              string
+		In1 context.Context
+		In2 string
+		In3 string
+		In4 string
 	}{
-		ContextMoqParam: contextMoqParam,
-		S1:              s1,
-		S2:              s2,
-		S3:              s3,
+		In1: in1,
+		In2: in2,
+		In3: in3,
+		In4: in4,
 	}
-	mock.lockGetRecipe.Lock()
+	lockRecipeAPIClientMockGetRecipe.Lock()
 	mock.calls.GetRecipe = append(mock.calls.GetRecipe, callInfo)
-	mock.lockGetRecipe.Unlock()
-	return mock.GetRecipeFunc(contextMoqParam, s1, s2, s3)
+	lockRecipeAPIClientMockGetRecipe.Unlock()
+	return mock.GetRecipeFunc(in1, in2, in3, in4)
 }
 
 // GetRecipeCalls gets all the calls that were made to GetRecipe.
 // Check the length with:
 //     len(mockedRecipeAPIClient.GetRecipeCalls())
 func (mock *RecipeAPIClientMock) GetRecipeCalls() []struct {
-	ContextMoqParam context.Context
-	S1              string
-	S2              string
-	S3              string
+	In1 context.Context
+	In2 string
+	In3 string
+	In4 string
 } {
 	var calls []struct {
-		ContextMoqParam context.Context
-		S1              string
-		S2              string
-		S3              string
+		In1 context.Context
+		In2 string
+		In3 string
+		In4 string
 	}
-	mock.lockGetRecipe.RLock()
+	lockRecipeAPIClientMockGetRecipe.RLock()
 	calls = mock.calls.GetRecipe
-	mock.lockGetRecipe.RUnlock()
+	lockRecipeAPIClientMockGetRecipe.RUnlock()
 	return calls
 }


### PR DESCRIPTION
### What

- Populate `id` and `href` dimension values from recipe code lists (if provided), instead of Cantabular response.
- Modified unit tests to validate the dimensions that we send to dataset-api, and validate that the expected values are sent.

trello card: https://trello.com/c/fEsZyzBI/5402-dataset-api-returning-incorrect-dimension-information-for-cantabular-dataset-5

### How to review

- Make sure code changes make sense
- Make sure unit tests pass

### Who can review

Anyone
