### PR TITLE
Flag geography codelists

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/ONSdigital/dp-api-clients-go/v2 v2.8.1
 	github.com/ONSdigital/dp-component-test v0.6.3
 	github.com/ONSdigital/dp-healthcheck v1.2.3
-	github.com/ONSdigital/dp-import v1.2.1
+	github.com/ONSdigital/dp-import v1.3.1
 	github.com/ONSdigital/dp-kafka/v3 v3.1.1
 	github.com/ONSdigital/dp-net v1.2.0
 	github.com/ONSdigital/log.go/v2 v2.0.9

--- a/go.sum
+++ b/go.sum
@@ -52,8 +52,10 @@ github.com/ONSdigital/dp-healthcheck v1.0.5/go.mod h1:2wbVAUHMl9+4tWhUlxYUuA1dnf
 github.com/ONSdigital/dp-healthcheck v1.1.0/go.mod h1:vZwyjMJiCHjp/sJ2R1ZEqzZT0rJ0+uHVGwxqdP4J5vg=
 github.com/ONSdigital/dp-healthcheck v1.2.3 h1:8/qTe0TjXouQWW0jgrtDGMFl+fUWigfyntL+q96GUSY=
 github.com/ONSdigital/dp-healthcheck v1.2.3/go.mod h1:XUhXoDIWPCdletDtpDOoXhmDFcc9b/kbedx96jN75aI=
-github.com/ONSdigital/dp-import v1.2.1 h1:IySfrNsrsWaqFAVgZSaOEaE5StVUJ1TJIZgVAFdBIxk=
-github.com/ONSdigital/dp-import v1.2.1/go.mod h1:WTsFDrvob+eTEj/JIuzUWdwLhHPRf3KETVDT9fEK+88=
+github.com/ONSdigital/dp-import v1.3.0 h1:6f6NuEkXqYCOXIoKaBmZ2yfAV4g64+eeinlvvx4UMfU=
+github.com/ONSdigital/dp-import v1.3.0/go.mod h1:WTsFDrvob+eTEj/JIuzUWdwLhHPRf3KETVDT9fEK+88=
+github.com/ONSdigital/dp-import v1.3.1 h1:Q9JYyBry72BUcG9ovDI5pce0lUVoLupUnxwyArIrIGU=
+github.com/ONSdigital/dp-import v1.3.1/go.mod h1:WTsFDrvob+eTEj/JIuzUWdwLhHPRf3KETVDT9fEK+88=
 github.com/ONSdigital/dp-kafka/v2 v2.2.0/go.mod h1:lFw9GGYpW8N6dG7g2wLQgCJL9vpo17RvOzCsdMRCapQ=
 github.com/ONSdigital/dp-kafka/v2 v2.4.3 h1:Sb5nc4M3RsDMDmclsTqyjTMP6IBD7dRkv3kaIM26LLs=
 github.com/ONSdigital/dp-kafka/v2 v2.4.3/go.mod h1:W7BZ0zUmIuOMne18Pe3I4V/nF41Ynwy0N5A4+s7ahaw=

--- a/handler/instance_started_test.go
+++ b/handler/instance_started_test.go
@@ -970,24 +970,24 @@ func TestTriggerImportDimensionOptions(t *testing.T) {
 		wg := &sync.WaitGroup{}
 
 		Convey("When TriggerImportDimensionOptions is called", func(c C) {
+			codelists := []recipe.CodeList{
+				{
+					IsCantabularGeography: &trueValue,
+				},
+				{
+					IsCantabularGeography: &falseValue, // this indicates the non-geography item
+				},
+			}
+
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				codelists := []recipe.CodeList{
-					{
-						IsCantabularGeography: &trueValue,
-					},
-					{
-						IsCantabularGeography: &falseValue, // this indicates the non-geography item
-					},
-				}
-
 				r := &recipe.Recipe{
 					Format:         "cantabular_flexible_table",
 					CantabularBlob: "cantabular_blob",
 				}
 
-				err := h.TriggerImportDimensionOptions(r, &codelists, &event.InstanceStarted{
+				err := h.TriggerImportDimensionOptions(r, codelists, &event.InstanceStarted{
 					RecipeID:       testRecipeID,
 					InstanceID:     testInstanceID,
 					JobID:          testJobID,
@@ -999,13 +999,17 @@ func TestTriggerImportDimensionOptions(t *testing.T) {
 			}()
 
 			Convey("Then the validateMessagesCount consumes one message", func() {
-				expected := []event.CategoryDimensionImport{
-					{
+				expected := make([]event.CategoryDimensionImport, 0)
+
+				for _, cl := range codelists {
+					event := event.CategoryDimensionImport{
 						JobID:          testJobID,
 						InstanceID:     testInstanceID,
 						DimensionID:    "",
 						CantabularBlob: "cantabular_blob",
-					},
+						IsGeography:    *cl.IsCantabularGeography,
+					}
+					expected = append(expected, event)
 				}
 
 				var result int
@@ -1016,7 +1020,7 @@ func TestTriggerImportDimensionOptions(t *testing.T) {
 				}
 
 				wg.Wait()
-				So(result, ShouldEqual, 1)
+				So(result, ShouldEqual, 2)
 
 				err := producer.Close(ctx)
 				So(err, ShouldBeNil)
@@ -1046,22 +1050,22 @@ func TestTriggerImportDimensionOptionsNonGeography(t *testing.T) {
 		)
 
 		wg := &sync.WaitGroup{}
-
 		Convey("When TriggerImportDimensionOptions is called", func(c C) {
+			codelists := []recipe.CodeList{
+				{
+					IsCantabularGeography: &trueValue,
+				},
+				{
+					IsCantabularGeography: &trueValue,
+				},
+			}
+
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				codelists := []recipe.CodeList{
-					{
-						IsCantabularGeography: &trueValue,
-					},
-					{
-						IsCantabularGeography: &trueValue,
-					},
-				}
 
 				errs := handler.NewError(
-					fmt.Errorf("no non-geography variables exist in the codelists"),
+					fmt.Errorf("only geography codelists exist in this instance, there must be at least one non-geography in the codelists"),
 					log.Data{},
 					false)
 
@@ -1070,7 +1074,7 @@ func TestTriggerImportDimensionOptionsNonGeography(t *testing.T) {
 					CantabularBlob: "cantabular_blob",
 				}
 
-				err := h.TriggerImportDimensionOptions(r, &codelists, &event.InstanceStarted{
+				err := h.TriggerImportDimensionOptions(r, codelists, &event.InstanceStarted{
 					RecipeID:       testRecipeID,
 					InstanceID:     testInstanceID,
 					JobID:          testJobID,
@@ -1082,13 +1086,17 @@ func TestTriggerImportDimensionOptionsNonGeography(t *testing.T) {
 			}()
 
 			Convey("Then the validateMessagesCount consumes no messages", func() {
-				expected := []event.CategoryDimensionImport{
-					{
+				expected := make([]event.CategoryDimensionImport, 0)
+
+				for _, cl := range codelists {
+					event := event.CategoryDimensionImport{
 						JobID:          testJobID,
 						InstanceID:     testInstanceID,
 						DimensionID:    "",
 						CantabularBlob: "cantabular_blob",
-					},
+						IsGeography:    *cl.IsCantabularGeography,
+					}
+					expected = append(expected, event)
 				}
 
 				var result int
@@ -1099,7 +1107,7 @@ func TestTriggerImportDimensionOptionsNonGeography(t *testing.T) {
 				}
 
 				wg.Wait()
-				So(result, ShouldEqual, 0)
+				So(result, ShouldEqual, 2)
 
 				err := producer.Close(ctx)
 				So(err, ShouldBeNil)

--- a/handler/instance_started_test.go
+++ b/handler/instance_started_test.go
@@ -601,7 +601,6 @@ func TestCreateUpdateInstanceRequest_Happy(t *testing.T) {
 		}
 
 		req := h.CreateUpdateInstanceRequest(ctx, mfVariables, e, r, codelists, "2021")
-		fmt.Printf("req is: %v", req)
 
 		Convey("Then we get the expected result with two Dimensions", func() {
 
@@ -710,7 +709,6 @@ func TestCreateUpdateInstanceRequest_Flexible_NoGeography(t *testing.T) {
 		}
 
 		req := h.CreateUpdateInstanceRequest(ctx, mfVariables, e, r, codelists, "2021")
-		fmt.Printf("req is: %v", req)
 
 		Convey("Then we get the expected result with two Dimensions", func() {
 
@@ -820,7 +818,6 @@ func TestCreateUpdateInstanceRequest_Flexible_OneGeography(t *testing.T) {
 		}
 
 		req := h.CreateUpdateInstanceRequest(ctx, mfVariables, e, r, codelists, "2021")
-		fmt.Printf("req is: %v", req)
 
 		Convey("Then we get the expected single non-Geography Dimension", func() {
 
@@ -921,7 +918,6 @@ func TestCreateUpdateInstanceRequest_Flexible_BothGeography(t *testing.T) {
 		}
 
 		req := h.CreateUpdateInstanceRequest(ctx, mfVariables, e, r, codelists, "2021")
-		fmt.Printf("req is: %v", req)
 
 		Convey("Then we get the expected result with no Dimensions in it", func() {
 


### PR DESCRIPTION
### What

* To indicate `dp-import-cantabular-dimension-options` when consuming
  the kafka message to not update the instance.

* The message still needs to be consumed to determine that all
  dimensions have been processed so that it can mark the job as
  finished and complete

### How to review
In conjunction with https://github.com/ONSdigital/dp-import-cantabular-dimension-options/pull/41

### Who can review

Any developer
