### PR TITLE
Run docker-compose as host user

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 BINPATH ?= build
 
+MY_UID=$(shell id -u)
+MY_GID=$(shell id -g)
 BUILD_TIME=$(shell date +%s)
 GIT_COMMIT=$(shell git rev-parse HEAD)
 VERSION ?= $(shell git tag --points-at HEAD | grep ^v | head -n 1)
@@ -40,7 +42,7 @@ convey:
 
 .PHONY: test-component
 test-component:
-	cd features/compose && docker-compose up --build --abort-on-container-exit
+	cd features/compose && MY_UID=$(MY_UID) MY_GID=$(MY_GID) docker-compose up --build --abort-on-container-exit
 	cd features/compose && docker-compose down --volume
 	echo "please ignore error codes 0, like so: ERROR[xxxx] 0, as error code 0 means that there was no error"
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ https://github.com/ONSdigital/dp-compose/cantabular-import
 
 ## Component Tests ##
 
-* `sudo make test-component`
+* `make test-component`
 
 ### Configuration
 

--- a/features/compose/dp-import-cantabular-dataset.yml
+++ b/features/compose/dp-import-cantabular-dataset.yml
@@ -5,6 +5,7 @@ services:
         build:
             context: ../..
             dockerfile: Dockerfile.local
+        user: "${MY_UID}:${MY_UID}"
         command:
             - go 
             - test 


### PR DESCRIPTION
### What

When creating the `.go` volume on the host machine it was being created
using the default user, i.e, root.

This is not advisable as it will force the host user to either change
the permissions of the `.go` folder, run `sudo make test-component` or
delete the `.go` for subsquent executions.

Also we should not allow the default root user to create volumes on our
host machines as it is a security risk.

### How to review

1. Check to see if you have a `.go` folder: `ls -la`
2. If exists, check the ownership and permissions. They are probably owned by root and no writing permissions for group or others. Delete the folder `sudo rm -rf .go`
3. Execute `make test-component`
4. List the permissions and ownership of that folder. it should be owned by your host user, i.e, no `root` user

### Who can review

any developer.
