### PR TITLE
Ensure default cantabular geography variable is added to CSVHeaders

### DIFF
--- a/handler/instance_started.go
+++ b/handler/instance_started.go
@@ -219,7 +219,7 @@ func (h *InstanceStarted) CreateUpdateInstanceRequest(ctx context.Context, mf gq
 			continue
 		}
 
-		if r.Format == "cantabular_flexible_table" {
+		if r.Format == "cantabular_flexible_table" && isNotCantatularDefaultGeography(codelists, i) {
 			if codelists[i].IsCantabularGeography != nil {
 				if *codelists[i].IsCantabularGeography {
 					continue
@@ -259,7 +259,7 @@ func (h *InstanceStarted) TriggerImportDimensionOptions(r *recipe.Recipe, codeli
 	var geographyCount int
 	tc := len(codelists)
 
-	for _, cl := range codelists {
+	for i, cl := range codelists {
 		ie := event.CategoryDimensionImport{
 			DimensionID:    cl.ID,
 			JobID:          e.JobID,
@@ -267,9 +267,9 @@ func (h *InstanceStarted) TriggerImportDimensionOptions(r *recipe.Recipe, codeli
 			CantabularBlob: r.CantabularBlob,
 		}
 
-		if r.Format == "cantabular_flexible_table" {
-			if cl.IsCantabularGeography != nil && cl.IsCantabularDefaultGeography != nil {
-				if *cl.IsCantabularGeography && !*cl.IsCantabularDefaultGeography {
+		if r.Format == "cantabular_flexible_table" && isNotCantatularDefaultGeography(codelists, i) {
+			if cl.IsCantabularGeography != nil {
+				if *cl.IsCantabularGeography {
 					geographyCount++
 					// To indicate `dp-import-cantabular-dimension-options` when consuming the kafka message to not update the instance
 					// The message still needs to be consumed to determine that all dimensions have been processed
@@ -336,4 +336,8 @@ func (h *InstanceStarted) handleError(ctx context.Context, e *event.InstanceStar
 	}
 
 	return err
+}
+
+func isNotCantatularDefaultGeography(cl []recipe.CodeList, i int) bool {
+	return !(cl[i].IsCantabularDefaultGeography != nil && *cl[i].IsCantabularDefaultGeography)
 }

--- a/handler/instance_started_test.go
+++ b/handler/instance_started_test.go
@@ -654,6 +654,7 @@ func TestCreateUpdateInstanceRequest_Happy(t *testing.T) {
 
 func TestCreateUpdateInstanceRequest_Flexible_NoGeography(t *testing.T) {
 	cfg := config.Config{}
+	trueValue := true
 	falseValue := false
 
 	Convey("Given CreateUpdateInstanceRequest() is called with two Edges and the format is of type: cantabular_flexible_table, and neither edges are Geography", t, func() {
@@ -705,11 +706,11 @@ func TestCreateUpdateInstanceRequest_Flexible_NoGeography(t *testing.T) {
 		codelists := []recipe.CodeList{
 			{
 				IsCantabularGeography:        &falseValue,
-				IsCantabularDefaultGeography: &falseValue,
+				IsCantabularDefaultGeography: &trueValue,
 			},
 			{
 				IsCantabularGeography:        &falseValue,
-				IsCantabularDefaultGeography: &falseValue,
+				IsCantabularDefaultGeography: &trueValue,
 			},
 		}
 
@@ -820,7 +821,7 @@ func TestCreateUpdateInstanceRequest_Flexible_OneGeography(t *testing.T) {
 			},
 			{
 				IsCantabularGeography:        &falseValue,
-				IsCantabularDefaultGeography: &falseValue,
+				IsCantabularDefaultGeography: &trueValue,
 			},
 		}
 


### PR DESCRIPTION
### What

Ensure default cantabular geography variable is added to CSVHeaders
Resolves [5618](https://trello.com/c/2AsDjr3W/5618-ensure-default-cantabular-geography-variable-is-added-to-instance-record)

### How to review
Look a the AC of the ticket.

### Who can review
Any developer