### PR TITLE
Remove zookeeper from the component tests dependencies

### DIFF
--- a/features/compose/dp-import-cantabular-dataset.yml
+++ b/features/compose/dp-import-cantabular-dataset.yml
@@ -17,7 +17,6 @@ services:
             - ../..:/dp-import-cantabular-dataset
         depends_on:
             - kafka-1
-            - zookeeper-1
         ports:
             - "26100:26100"
         environment:


### PR DESCRIPTION
### What

We were seeing the component tests fail due to a zookeeper exception.
Zookeeper is being brought by the dp-component-tests dependency

### How to review

Understand if the tests pass

### Who can review

Any developer
