### PR TITLE
5885 add extra layers of validation when importing cantabular instances

### DIFF
--- a/handler/instance_started.go
+++ b/handler/instance_started.go
@@ -202,6 +202,8 @@ func (h *InstanceStarted) getCodeListsFromInstance(i *recipe.Instance) ([]string
 }
 
 func (h *InstanceStarted) CreateUpdateInstanceRequest(ctx context.Context, vars gql.Variables, e *event.InstanceStarted, r *recipe.Recipe, codelists []recipe.CodeList, edition string) dataset.UpdateInstance {
+	var falseValue = false
+
 	req := dataset.UpdateInstance{
 		Edition:    edition,
 		CSVHeader:  []string{cantabularTable},
@@ -251,6 +253,11 @@ func (h *InstanceStarted) CreateUpdateInstanceRequest(ctx context.Context, vars 
 			NumberOfOptions: edge.Node.Categories.TotalCount,
 			IsAreaType:      cl.IsCantabularGeography,
 		}
+
+		if d.IsAreaType == nil {
+			d.IsAreaType = &falseValue
+		}
+
 		req.Dimensions = append(req.Dimensions, d)
 		req.CSVHeader = append(req.CSVHeader, edge.Node.Name)
 	}

--- a/handler/instance_started_test.go
+++ b/handler/instance_started_test.go
@@ -136,6 +136,7 @@ func TestInstanceStartedHandler_HandleHappy(t *testing.T) {
 								Name:            "Test Variable",
 								Variable:        "NameVar1",
 								NumberOfOptions: 100,
+								IsAreaType:      &falseValue,
 							},
 							{
 								ID:              "test-mapped-variable",
@@ -144,6 +145,7 @@ func TestInstanceStartedHandler_HandleHappy(t *testing.T) {
 								Name:            "Test Mapped Variable",
 								Variable:        "NameVar2",
 								NumberOfOptions: 123,
+								IsAreaType:      &falseValue,
 							},
 						},
 					})


### PR DESCRIPTION
### What

Add extra layer of validation when importing cantabular instances
Trello - https://trello.com/c/cZ7mYUyM/5885-extra-validation-for-isareatype-in-recipe-api-and-import-api

### How to review

Confirm changes match the changes requested in Trello ticket

### Who can review

Anyone
